### PR TITLE
Add types entry to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "require": "./dist/index.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Exports field needs types definition for each entry in order to work correctly with bundler mode for typescript (tsconfig).
```
error TS7016: Could not find a declaration file for module 'socket.io-mock-ts'. '/app/build/node_modules/socket.io-mock-ts/dist/index.es.js' implicitly has an 'any' type.
  There are types at '/app/node_modules/socket.io-mock-ts/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'socket.io-mock-ts' library may need to update its package.json or typings.

2 import { SocketServerMock } from 'socket.io-mock-ts'
```