### PR TITLE
ci: add npm publish workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
           cache: yarn
           registry-url: https://registry.npmjs.org
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,6 @@ jobs:
           cache: yarn
           registry-url: https://registry.npmjs.org
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,5 @@
     "vite-plugin-checker": "^0.4.4",
     "vite-plugin-dts": "^1.0.5",
     "vitest": "^0.8.3"
-  },
-  "packageManager": "yarn@4.13.0"
+  }
 }


### PR DESCRIPTION
- Adds `publish.yml` workflow triggered via `workflow_dispatch` with a `patch`/`minor`/`major` bump input
- Bumps version from npm, builds, publishes with provenance (OIDC trusted publishing)
- Commits version bump, tags release, and creates a GitHub Release with changelog
- Fixes repository URLs (was pointing to `moodiest` fork)
- Removes `packageManager` field to avoid Corepack requirement on CI